### PR TITLE
Show a conflict with default Symfony autowiring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
 	"autoload": {
 		"psr-0": { "Kutny\\AutowiringBundle": "" }
 	},
+	"conflict": {
+		"symfony/dependency-injection": "^2.8|^3.0"
+	},
 	"target-dir": "Kutny/AutowiringBundle"
 }


### PR DESCRIPTION
As described in http://symfony.com/blog/new-in-symfony-2-8-service-auto-wiring and https://github.com/sitepoint/awesome-symfony/pull/59, this bundle is useful if not used with Symfony 2.8+, otherwise there would be a conflict.
