### PR TITLE
Autowiring is part of core from 2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.2"
+		"php": ">=5.3.2",
+		"symfony/dependency-injection": "<2.8"
 	},
 	"autoload": {
 		"psr-0": { "Kutny\\AutowiringBundle": "" }


### PR DESCRIPTION
Help people by letting them know that they don't need this bundle if they run Symfony 2.8+.

http://symfony.com/blog/new-in-symfony-2-8-service-auto-wiring
